### PR TITLE
Fix GetMachineStatus for machine's that were already released.

### DIFF
--- a/pkg/provider/core.go
+++ b/pkg/provider/core.go
@@ -20,6 +20,7 @@ package provider
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/driver"
@@ -134,6 +135,12 @@ func (p *Provider) DeleteMachine(ctx context.Context, req *driver.DeleteMachineR
 		return nil, err
 	}
 
+	clusterIDTag, err := extractClusterTag(providerSpec.Tags)
+	if err != nil {
+		klog.V(2).Infof("machine deletion request for machine %q failed because provider spec did not contain metal-stack cluster tag", req.Machine.Name)
+		return nil, status.Error(codes.Internal, "machine deletion request failed because provider spec did not contain metal-stack cluster tag for")
+	}
+
 	m, err := p.initDriver(req.Secret)
 	if err != nil {
 		klog.Error(err.Error())
@@ -145,6 +152,7 @@ func (p *Provider) DeleteMachine(ctx context.Context, req *driver.DeleteMachineR
 	mfr := &metalgo.MachineFindRequest{
 		ID:                &id,
 		AllocationProject: &providerSpec.Project,
+		Tags:              []string{clusterIDTag},
 	}
 
 	resp, err := m.MachineFind(mfr)
@@ -195,15 +203,8 @@ func (p *Provider) GetMachineStatus(ctx context.Context, req *driver.GetMachineS
 		return nil, err
 	}
 
-	clusterIDTag := ""
-	for _, t := range providerSpec.Tags {
-		if strings.HasPrefix(t, tag.ClusterID) {
-			clusterIDTag = t
-			break
-		}
-	}
-
-	if clusterIDTag == "" {
+	clusterIDTag, err := extractClusterTag(providerSpec.Tags)
+	if err != nil {
 		klog.V(2).Infof("get request for machine %q failed because provider spec did not contain metal-stack cluster tag", req.Machine.Name)
 		return nil, status.Error(codes.Internal, "get machine request failed because provider spec did not contain metal-stack cluster tag for")
 	}
@@ -226,22 +227,23 @@ func (p *Provider) GetMachineStatus(ctx context.Context, req *driver.GetMachineS
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	klog.V(2).Infof("machine get request has been processed successfully for %q", req.Machine.Name)
-
 	if resp.Machine.Allocation == nil {
+		klog.V(2).Infof("machine already released: %q", req.Machine.Name)
 		return nil, status.Error(codes.NotFound, "machine already released")
 	}
 
-	found := false
-	for _, t := range resp.Machine.Tags {
-		if t == clusterIDTag {
-			found = true
-			break
-		}
+	machineClusterIDTag, err := extractClusterTag(resp.Machine.Tags)
+	if err != nil {
+		klog.V(2).Infof("machine has no cluster tag anymore: %q", req.Machine.Name)
+		return nil, status.Error(codes.NotFound, "machine has no cluster tag anymore")
 	}
-	if !found {
+
+	if machineClusterIDTag != clusterIDTag {
+		klog.V(2).Infof("machine does not belong to this cluster anymore: %q", req.Machine.Name)
 		return nil, status.Error(codes.NotFound, "machine does not belong to this cluster anymore")
 	}
+
+	klog.V(2).Infof("machine get request has been processed successfully for %q", req.Machine.Name)
 
 	return &driver.GetMachineStatusResponse{
 		ProviderID: encodeMachineID(*resp.Machine.Partition.ID, *resp.Machine.ID),
@@ -278,15 +280,8 @@ func (p *Provider) ListMachines(ctx context.Context, req *driver.ListMachinesReq
 
 	listOfVMs := make(map[string]string)
 
-	clusterIDTag := ""
-	for _, t := range providerSpec.Tags {
-		if strings.HasPrefix(t, tag.ClusterID) {
-			clusterIDTag = t
-			break
-		}
-	}
-
-	if clusterIDTag == "" {
+	clusterIDTag, err := extractClusterTag(providerSpec.Tags)
+	if err != nil {
 		klog.V(2).Infof("list machines request failed because provider spec did not contain metal-stack cluster tag for %q", req.MachineClass.Name)
 		return nil, status.Error(codes.Internal, "list machines request failed because provider spec did not contain metal-stack cluster tag for")
 	}
@@ -416,4 +411,13 @@ func (p *Provider) GenerateMachineClassForMigration(ctx context.Context, req *dr
 
 	klog.V(2).Infof("MigrateMachineClass request has been processed successfully for %q", req.ClassSpec)
 	return &driver.GenerateMachineClassForMigrationResponse{}, nil
+}
+
+func extractClusterTag(tags []string) (string, error) {
+	for _, t := range tags {
+		if strings.HasPrefix(t, tag.ClusterID) {
+			return t, nil
+		}
+	}
+	return "", fmt.Errorf("tag not found")
 }


### PR DESCRIPTION
Returns NotFound responses in case the machine was already released / already belongs to another cluster.