### PR TITLE
use only the nguid part of the volumeHandle for lightbits volumes

### DIFF
--- a/pkg/metal/core.go
+++ b/pkg/metal/core.go
@@ -362,7 +362,7 @@ func (p *Provider) GetVolumeIDs(ctx context.Context, req *driver.GetVolumeIDsReq
 		}
 
 		// use only the nguid part of the volumeHandle for lightbits volumes
-		if spec.CSI.Driver != "csi.lightbitslabs.com" {
+		if spec.CSI.Driver == "csi.lightbitslabs.com" {
 			// volumeHandle: mgmt:10.131.44.1:443,10.131.44.2:443,10.131.44.3:443|nguid:d22572da-a225-4578-ab1a-9318ac5155c3|proj:cd4eac58-46a5-4a31-b59f-2ec207baa817|scheme:grpcs
 			volumeHandleParts := strings.Split(spec.CSI.VolumeHandle, "|")
 			if len(volumeHandleParts) != 5 {

--- a/pkg/metal/core.go
+++ b/pkg/metal/core.go
@@ -349,32 +349,47 @@ func (p *Provider) ListMachines(ctx context.Context, req *driver.ListMachinesReq
 //
 // RESPONSE PARAMETERS (driver.GetVolumeIDsResponse)
 // VolumeIDs             []string                             VolumeIDs is a repeated list of VolumeIDs.
-func (p *Provider) GetVolumeIDs(ctx context.Context, req *driver.GetVolumeIDsRequest) (*driver.GetVolumeIDsResponse, error) {
+func (p *Provider) GetVolumeIDs(_ context.Context, req *driver.GetVolumeIDsRequest) (*driver.GetVolumeIDsResponse, error) {
 	// Log messages to track start and end of request
 	klog.V(2).Infof("GetVolumeIDs request has been received for %q", req.PVSpecs)
-	volumeIDs := []string{}
-	specs := req.PVSpecs
-	for i := range specs {
-		spec := specs[i]
-		if spec.CSI == nil {
+
+	var (
+		volumeIDs []string
+	)
+
+	for _, spec := range req.PVSpecs {
+		if spec == nil || spec.CSI == nil {
 			// Not a CSI volume
 			continue
 		}
 
-		// use only the nguid part of the volumeHandle for lightbits volumes
-		if spec.CSI.Driver == "csi.lightbitslabs.com" {
-			// volumeHandle: mgmt:10.131.44.1:443,10.131.44.2:443,10.131.44.3:443|nguid:d22572da-a225-4578-ab1a-9318ac5155c3|proj:cd4eac58-46a5-4a31-b59f-2ec207baa817|scheme:grpcs
-			volumeHandleParts := strings.Split(spec.CSI.VolumeHandle, "|")
-			if len(volumeHandleParts) != 5 {
-				klog.Errorf("invalid lightbits volumeHandle: %q", spec.CSI.VolumeHandle)
+		switch spec.CSI.Driver {
+		case "csi.lightbitslabs.com":
+			fields := map[string]string{}
+			for _, part := range strings.Split(spec.CSI.VolumeHandle, "|") {
+				k, v, ok := strings.Cut(part, ":")
+				if !ok {
+					continue
+				}
+				fields[k] = v
 			}
-			volumeIDs = append(volumeIDs, volumeHandleParts[1])
-			continue
-		}
 
-		volumeIDs = append(volumeIDs, spec.CSI.VolumeHandle)
+			nguid, ok := fields["nguid"]
+			if ok {
+				volumeIDs = append(volumeIDs, nguid)
+				continue
+			}
+
+			klog.Errorf("invalid lightbits volumeHandle (missing nguid): %s", spec.CSI.VolumeHandle)
+
+			fallthrough
+		default:
+			volumeIDs = append(volumeIDs, spec.CSI.VolumeHandle)
+		}
 	}
+
 	klog.V(2).Infof("GetVolumeIDs request has been processed successfully for %q", req.PVSpecs)
+
 	return &driver.GetVolumeIDsResponse{VolumeIDs: volumeIDs}, nil
 }
 

--- a/pkg/metal/core.go
+++ b/pkg/metal/core.go
@@ -361,6 +361,17 @@ func (p *Provider) GetVolumeIDs(ctx context.Context, req *driver.GetVolumeIDsReq
 			continue
 		}
 
+		// use only the nguid part of the volumeHandle for lightbits volumes
+		if spec.CSI.Driver != "csi.lightbitslabs.com" {
+			// volumeHandle: mgmt:10.131.44.1:443,10.131.44.2:443,10.131.44.3:443|nguid:d22572da-a225-4578-ab1a-9318ac5155c3|proj:cd4eac58-46a5-4a31-b59f-2ec207baa817|scheme:grpcs
+			volumeHandleParts := strings.Split(spec.CSI.VolumeHandle, "|")
+			if len(volumeHandleParts) != 5 {
+				klog.Errorf("invalid lightbits volumeHandle: %q", spec.CSI.VolumeHandle)
+			}
+			volumeIDs = append(volumeIDs, volumeHandleParts[1])
+			continue
+		}
+
 		volumeIDs = append(volumeIDs, spec.CSI.VolumeHandle)
 	}
 	klog.V(2).Infof("GetVolumeIDs request has been processed successfully for %q", req.PVSpecs)

--- a/pkg/metal/core_test.go
+++ b/pkg/metal/core_test.go
@@ -1,0 +1,73 @@
+// Package provider contains the cloud provider specific implementations to manage machines
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gardener/machine-controller-manager/pkg/util/provider/driver"
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestProvider_GetVolumeIDs(t *testing.T) {
+	tests := []struct {
+		name    string
+		req     *driver.GetVolumeIDsRequest
+		want    *driver.GetVolumeIDsResponse
+		wantErr error
+	}{
+		{
+			name: "valid lightbits volume",
+			req: &driver.GetVolumeIDsRequest{
+				PVSpecs: []*corev1.PersistentVolumeSpec{
+					{
+
+						PersistentVolumeSource: corev1.PersistentVolumeSource{
+							CSI: &corev1.CSIPersistentVolumeSource{
+								Driver:       "csi.lightbitslabs.com",
+								VolumeHandle: "mgmt:10.131.44.1:443,10.131.44.2:443,10.131.44.3:443|nguid:d22572da-a225-4578-ab1a-9318ac5155c3|proj:cd4eac58-46a5-4a31-b59f-2ec207baa817|scheme:grpcs",
+							},
+						},
+					},
+				},
+			},
+			want: &driver.GetVolumeIDsResponse{
+				VolumeIDs: []string{"d22572da-a225-4578-ab1a-9318ac5155c3"},
+			},
+		},
+		{
+			name: "invalid lightbits volume",
+			req: &driver.GetVolumeIDsRequest{
+				PVSpecs: []*corev1.PersistentVolumeSpec{
+					{
+
+						PersistentVolumeSource: corev1.PersistentVolumeSource{
+							CSI: &corev1.CSIPersistentVolumeSource{
+								Driver:       "csi.lightbitslabs.com",
+								VolumeHandle: "mgmt:10.131.44.1:443,10.131.44.2:443,10.131.44.3:443|proj:cd4eac58-46a5-4a31-b59f-2ec207baa817|scheme:grpcs",
+							},
+						},
+					},
+				},
+			},
+			want: &driver.GetVolumeIDsResponse{
+				VolumeIDs: []string{"mgmt:10.131.44.1:443,10.131.44.2:443,10.131.44.3:443|proj:cd4eac58-46a5-4a31-b59f-2ec207baa817|scheme:grpcs"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Provider{}
+
+			got, err := p.GetVolumeIDs(context.Background(), tt.req)
+
+			if diff := cmp.Diff(tt.wantErr, err); diff != "" {
+				t.Errorf("err diff = %s", diff)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("diff = %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Currently, we use the full volumehandle for identification of attached volumes.

This does not work correctly for lightbits-volumes and every volume-detach runs in the detach-timeout of 2m:
```
machine-controller-manager-provider-metal I0523 11:16:37.741716       1 drain.go:878] Found volume:mgmt:10.131.44.1:443,10.131.44.2:443,10.131.44.3:443|nguid:605dc483-61fe-4793-b797-e3b284c03615|proj:cd4eac58-46a5-4a31-b59f-2ec207baa817|scheme:grpcs still attached to node "shoot--p4jxn2--mwen-group-0-8d94d-xjlc6". Will re-check in 5s
machine-controller-manager-provider-metal I0523 11:16:42.742862       1 drain.go:878] Found volume:mgmt:10.131.44.1:443,10.131.44.2:443,10.131.44.3:443|nguid:605dc483-61fe-4793-b797-e3b284c03615|proj:cd4eac58-46a5-4a31-b59f-2ec207baa817|scheme:grpcs still attached to node "shoot--p4jxn2--mwen-group-0-8d94d-xjlc6". Will re-check in 5s
(...)
machine-controller-manager-provider-metal I0523 11:18:57.761247       1 drain.go:878] Found volume:mgmt:10.131.44.1:443,10.131.44.2:443,10.131.44.3:443|nguid:605dc483-61fe-4793-b797-e3b284c03615|proj:cd4eac58-46a5-4a31-b59f-2ec207baa817|scheme:grpcs still attached to node "shoot--p4jxn2--mwen-group-0-8d94d-xjlc6". Will re-check in 5s
machine-controller-manager-provider-metal I0523 11:19:02.762450       1 drain.go:878] Found volume:mgmt:10.131.44.1:443,10.131.44.2:443,10.131.44.3:443|nguid:605dc483-61fe-4793-b797-e3b284c03615|proj:cd4eac58-46a5-4a31-b59f-2ec207baa817|scheme:grpcs still attached to node "shoot--p4jxn2--mwen-group-0-8d94d-xjlc6". Will re-check in 5s

machine-controller-manager-provider-metal W0523 11:19:07.762598       1 drain.go:845] Timeout occurred while waiting for PVs to detach from node "shoot--p4jxn2--mwen-group-0-8d94d-xjlc6"
machine-controller-manager-provider-metal E0523 11:19:07.762638       1 drain.go:752] error when waiting for volume to detach from node. Err: timeout while waiting for PVs to detach from node
```

For nodes with a lot of volumes, this can lead to a very long drain time.

The reason, why mcm thinks the volume is still attached is, that lightbits volumes have a pipe symbol in the volumehandler and mcm uses a regex for matching: https://github.com/gardener/machine-controller-manager/blob/v0.48.3/pkg/util/provider/drain/drain.go#L874 and e.g. `|scheme:grpcs` matches for every volume ...

Result after this PR:

```plaintext
machine-controller-manager-provider-metal I0523 11:36:07.062593       1 drain.go:781] Pod + volume detachment from node shoot--p4jxn2--mwen-group-0-8d94d-xjlc6 + volume reattachment to another node for Pod default/myapp20-0 took 45.063156547s
machine-controller-manager-provider-metal I0523 11:36:47.116673       1 drain.go:781] Pod + volume detachment from node shoot--p4jxn2--mwen-group-0-8d94d-xjlc6 + volume reattachment to another node for Pod default/myapp21-0 took 40.054059368s
machine-controller-manager-provider-metal I0523 11:37:27.172106       1 drain.go:781] Pod + volume detachment from node shoot--p4jxn2--mwen-group-0-8d94d-xjlc6 + volume reattachment to another node for Pod default/myapp22-0 took 40.055413074s
machine-controller-manager-provider-metal I0523 11:38:07.228383       1 drain.go:781] Pod + volume detachment from node shoot--p4jxn2--mwen-group-0-8d94d-xjlc6 + volume reattachment to another node for Pod default/myapp23-0 took 40.056260128s
machine-controller-manager-provider-metal I0523 11:38:47.283647       1 drain.go:781] Pod + volume detachment from node shoot--p4jxn2--mwen-group-0-8d94d-xjlc6 + volume reattachment to another node for Pod default/myapp24-0 took 40.055238513s
```
=> ~40sec for each pod (30s terminationGracePeriodSeconds + 10sec volume detachment/reattachment)



